### PR TITLE
[Fix] Eliminacion linea cambio posicion enemigos

### DIFF
--- a/src/ecs/systems/s_enemy_movement.py
+++ b/src/ecs/systems/s_enemy_movement.py
@@ -21,6 +21,5 @@ def system_enemy_movement(world:esper.World, delta_time:float, screen:pygame.Sur
 
     for _, (c_t, c_v, c_s, c_e) in components:
         c_v.vel.x *= direction
-        c_t.pos.x += c_v.vel.x * delta_time
 
  


### PR DESCRIPTION
Se elimina linea en el systema system_enemy_movement de acuerdo a recomendacion del profesor 

<img width="346" alt="image" src="https://github.com/Laurarestrepo03/Ocarina-Galaxian/assets/124101392/198b6437-1598-4987-9b60-d08f59d5fe40">
