### PR TITLE
[Fix] Velocidad de las estrellas en pausa, velocidad de jugador y otros ajustes

### DIFF
--- a/assets/cfg/enemies.json
+++ b/assets/cfg/enemies.json
@@ -73,6 +73,6 @@
             ]      
         },
         "bullet_count": 2,
-        "points": 150
+        "points": 60
     }
 }

--- a/assets/cfg/player.json
+++ b/assets/cfg/player.json
@@ -4,5 +4,5 @@
         "x": 128,
         "y": 220
     },
-    "input_velocity": 100
+    "input_velocity": 85
 }

--- a/src/create/prefab_creator.py
+++ b/src/create/prefab_creator.py
@@ -89,13 +89,13 @@ def create_input_player(ecs_world:esper.World):
 
 def create_star(ecs_world:esper.World, window_cfg, starfield_cfg):
     for _ in range(starfield_cfg["number_of_stars"]):
+        star_size = pygame.Vector2(starfield_cfg["size"]["h"], starfield_cfg["size"]["w"])
         star_pos = pygame.Vector2(random.randint(0, window_cfg["size"]["w"]),
                              random.randint(0, window_cfg["size"]["h"]))
         star_vel = pygame.Vector2(random.uniform(0, 0), random.uniform(starfield_cfg["vertical_speed"]["min"], starfield_cfg["vertical_speed"]["max"]))
         star_color = random.choice(starfield_cfg["star_colors"])
-        star_surface = pygame.Surface((starfield_cfg["size"]["h"], starfield_cfg["size"]["w"]))
-        star_surface.fill((star_color["r"], star_color["g"], star_color["b"]))
-        star_entity = create_sprite(ecs_world, star_pos, star_vel, star_surface)
+        star_color = pygame.Color(star_color["r"], star_color["g"], star_color["b"])
+        star_entity = create_square(ecs_world, star_size, star_pos, star_vel, star_color)
         ecs_world.add_component(star_entity, CBlink(starfield_cfg["blink_rate"]["min"], starfield_cfg["blink_rate"]["max"]))
         ecs_world.add_component(star_entity, CTagStar())
 

--- a/src/ecs/systems/s_player_bullet_state.py
+++ b/src/ecs/systems/s_player_bullet_state.py
@@ -12,14 +12,12 @@ from src.ecs.components.tags.c_tag_player import CTagPlayer
 def system_player_bullet_state(ecs_world:esper.World, explosion_cfg:dict, self):
     components = ecs_world.get_components(CTransform, CSurface, CPLayerBulletState)
     
-    response = ""
     for _, (c_t, c_s, c_pbs) in components:
         if c_pbs.state == PlayerBulletState.NOT_FIRED:
             _do_not_fired_state(ecs_world, c_t, c_s)
         elif c_pbs.state == PlayerBulletState.FIRED:
-            response = _do_fired_state(ecs_world, c_t, c_s, c_pbs, explosion_cfg, self)
+            _do_fired_state(ecs_world, c_t, c_s, c_pbs, explosion_cfg, self)
 
-    return response
 
 
 def _do_not_fired_state(ecs_world:esper.World, c_t:CTransform, c_s:CSurface):

--- a/src/ecs/systems/s_player_bullet_state.py
+++ b/src/ecs/systems/s_player_bullet_state.py
@@ -18,8 +18,6 @@ def system_player_bullet_state(ecs_world:esper.World, explosion_cfg:dict, self):
         elif c_pbs.state == PlayerBulletState.FIRED:
             _do_fired_state(ecs_world, c_t, c_s, c_pbs, explosion_cfg, self)
 
-
-
 def _do_not_fired_state(ecs_world:esper.World, c_t:CTransform, c_s:CSurface):
     player_components = ecs_world.get_components(CTransform, CSurface, CTagPlayer)
 

--- a/src/ecs/systems/s_star_field.py
+++ b/src/ecs/systems/s_star_field.py
@@ -6,11 +6,12 @@ from src.ecs.components.c_velocity import CVelocity
 from src.ecs.components.tags.c_tag_star import CTagStar
 
 
-def system_star_field(ecs_world:esper.World, window_cfg, delta_time):
+def system_star_field(ecs_world:esper.World, window_cfg, delta_time, execute_game):
     star_entities = ecs_world.get_components(CTransform, CVelocity, CTagStar)
     for entity, (c_transform, c_velocity, _) in star_entities:
         c_transform = ecs_world.component_for_entity(entity, CTransform)
-        c_transform.pos += c_velocity.vel * delta_time
+        if not execute_game:
+            c_transform.pos += c_velocity.vel * delta_time
         
         if c_transform.pos.y > window_cfg["size"]["h"]:
             c_transform.pos.y = 0

--- a/src/engine/game_engine.py
+++ b/src/engine/game_engine.py
@@ -121,12 +121,12 @@ class GameEngine:
                 self.is_running = False
 
     def _update(self):
-        #system_movement(self.ecs_world, self.delta_time)
         #system_screen_bounce(self.ecs_world, self.screen) # ver si en realidad se usa
-        system_star_field(self.ecs_world, self.window_cfg, self.delta_time)
+        system_star_field(self.ecs_world, self.window_cfg, self.delta_time, self.execute_game)
         system_blink(self.ecs_world, self.delta_time)
+        
         if self.execute_game:
-            
+
             system_movement(self.ecs_world, self.delta_time)
             system_enemy_movement(self.ecs_world, self.delta_time, self.screen)
             system_explosion_state(self.ecs_world)


### PR DESCRIPTION
- Closes #48 
- Closes #35 
- Ajusta la velocidad de las estrellas en pausa para que permanezca igual
- Reduce la velocidad de la nave del jugador
- Ajusta los puntos que da disparar una nave
- Ajusta la creación de estrellas, ahora se crean como cuadrados

https://github.com/Laurarestrepo03/Ocarina-Galaxian/assets/69609680/b01a742f-9502-4331-a92f-b3637989df6f

