### PR TITLE
[Fix] Delay en disparo de balas enemigas

### DIFF
--- a/assets/cfg/level_01.json
+++ b/assets/cfg/level_01.json
@@ -55,5 +55,7 @@
             "number_enemies": 10,
             "gap": 18
         }
-    ]
+    ],
+    "min_bullet_interval": 1,
+    "max_bullet_interval": 2
 }

--- a/src/create/prefab_creator.py
+++ b/src/create/prefab_creator.py
@@ -5,6 +5,7 @@ import pygame
 
 from src.ecs.components.c_animation import CAnimation
 from src.ecs.components.c_blink import CBlink
+from src.ecs.components.c_enemy_bullet_spawner import CEnemyBulletSpawner
 from src.ecs.components.c_enemy_spawner import Line
 from src.ecs.components.c_explosion_state import CExplosionState
 from src.ecs.components.c_player_bullet_state import CPLayerBulletState
@@ -155,3 +156,7 @@ def create_text(world:esper.World, text_info:dict, text=None) -> int:
     world.add_component(text_entity, CSurface.from_text(text, text_font, text_color))
     
     return text_entity
+
+def create_enemy_bullet_spawner(ecs_world:esper.World, lvl_info:dict):
+    spawner_entity = ecs_world.create_entity()
+    ecs_world.add_component(spawner_entity, CEnemyBulletSpawner(lvl_info))

--- a/src/ecs/components/c_enemy_bullet_spawner.py
+++ b/src/ecs/components/c_enemy_bullet_spawner.py
@@ -1,0 +1,10 @@
+import random
+
+class CEnemyBulletSpawner:
+    def __init__(self, lvl_info:dict) -> None:
+        self.timer = 0
+        CEnemyBulletSpawner.change_max_time(lvl_info)
+
+    @classmethod
+    def change_max_time(cls, lvl_info):
+        cls.max_time = random.uniform(lvl_info["min_bullet_interval"], lvl_info["max_bullet_interval"])

--- a/src/ecs/systems/s_enemy_bullet_spawn.py
+++ b/src/ecs/systems/s_enemy_bullet_spawn.py
@@ -3,60 +3,69 @@ import pygame
 import random
 
 from src.create.prefab_creator import create_bullet
+from src.ecs.components.c_enemy_bullet_spawner import CEnemyBulletSpawner
 from src.ecs.components.c_surface import CSurface
 from src.ecs.components.c_transform import CTransform
 from src.ecs.components.tags.c_tag_bullet import BulletType
 from src.ecs.components.tags.c_tag_enemy import CTagEnemy, FiringState
 
-def system_enemy_bullet_spawn(ecs_world:esper.World, bullet_cfg:dict, enemies_cfg: dict, delta_time:float):
-    components = ecs_world.get_components(CTransform, CTagEnemy)
-    firing_enemy = None
-    non_fired_entities = []
-    fired_entities = []
+def system_enemy_bullet_spawn(ecs_world:esper.World, bullet_cfg:dict, enemies_cfg: dict, lvl_cfg:dict, delta_time:float):
+    spawner_component = ecs_world.get_component(CEnemyBulletSpawner)
 
-    for enemy_entity, (_, c_te) in components:
-        if c_te.firing_state == FiringState.FIRING:
-            firing_enemy = enemy_entity
-            break
-        elif c_te.firing_state == FiringState.NOT_FIRED:
-            non_fired_entities.append(enemy_entity)
-        elif c_te.firing_state == FiringState.FIRED:
-            fired_entities.append(enemy_entity)
+    for _, (c_spa) in spawner_component:
+        if c_spa.timer < c_spa.max_time:
+            c_spa.timer += delta_time
+        else:
+            enemy_components = ecs_world.get_components(CTransform, CTagEnemy)
+            firing_enemy = None
+            non_fired_entities = []
+            fired_entities = []
 
-    if len(fired_entities) == len(components):
-        for enemy_entity, (_, c_te) in components:
-            c_te.firing_state = FiringState.NOT_FIRED
-        non_fired_entities = fired_entities
+            for enemy_entity, (_, c_te) in enemy_components:
+                if c_te.firing_state == FiringState.FIRING:
+                    firing_enemy = enemy_entity
+                    break
+                elif c_te.firing_state == FiringState.NOT_FIRED:
+                    non_fired_entities.append(enemy_entity)
+                elif c_te.firing_state == FiringState.FIRED:
+                    fired_entities.append(enemy_entity)
 
-    if firing_enemy:
-        c_te = ecs_world.component_for_entity(firing_enemy, CTagEnemy)
-        c_te.timer += delta_time
+            if len(fired_entities) == len(enemy_components):
+                for enemy_entity, (_, c_te) in enemy_components:
+                    c_te.firing_state = FiringState.NOT_FIRED
+                non_fired_entities = fired_entities
 
-        if c_te.timer > 0.2:
-            c_t = ecs_world.component_for_entity(firing_enemy, CTransform)
-            pos = c_t.pos.copy()
-            c_s = ecs_world.component_for_entity(firing_enemy, CSurface)
-            area = c_s.area.copy()
-            size = area.size
-            final_pos = pygame.Vector2(pos.x + (size[0] / 2) - (bullet_cfg["size"]["x"] / 2),
-                                       pos.y + (size[1] / 2))
-            vel = pygame.Vector2(0, 1)
-            vel = vel.normalize() * bullet_cfg["velocity"]
+            if firing_enemy:
+                c_te = ecs_world.component_for_entity(firing_enemy, CTagEnemy)
+                c_te.timer += delta_time
 
-            create_bullet(ecs_world, bullet_cfg, final_pos, vel, BulletType.ENEMY)
+                if c_te.timer > 0.2:
+                    c_t = ecs_world.component_for_entity(firing_enemy, CTransform)
+                    pos = c_t.pos.copy()
+                    c_s = ecs_world.component_for_entity(firing_enemy, CSurface)
+                    area = c_s.area.copy()
+                    size = area.size
+                    final_pos = pygame.Vector2(pos.x + (size[0] / 2) - (bullet_cfg["size"]["x"] / 2),
+                                            pos.y + (size[1] / 2))
+                    vel = pygame.Vector2(0, 1)
+                    vel = vel.normalize() * bullet_cfg["velocity"]
 
-            c_te.timer = 0
-            c_te.bullets_fired += 1
+                    create_bullet(ecs_world, bullet_cfg, final_pos, vel, BulletType.ENEMY)
 
-            if c_te.bullets_fired == enemies_cfg[c_te.type]["bullet_count"]:
-                
-                c_te.firing_state = FiringState.FIRED
-                c_te.bullets_fired = 0
+                    c_te.timer = 0
+                    c_te.bullets_fired += 1
 
-    elif len(non_fired_entities) > 0:
-        random_enemy = random.choice(non_fired_entities)
-        c_te = ecs_world.component_for_entity(random_enemy, CTagEnemy)
-        c_te.firing_state = FiringState.FIRING
+                    if c_te.bullets_fired == enemies_cfg[c_te.type]["bullet_count"]:
+                        
+                        c_te.firing_state = FiringState.FIRED
+                        c_te.bullets_fired = 0
+                        c_spa.timer = 0
+                        CEnemyBulletSpawner.change_max_time(lvl_cfg)
+            
+            elif len(non_fired_entities) > 0:
+                random_enemy = random.choice(non_fired_entities)
+                c_te = ecs_world.component_for_entity(random_enemy, CTagEnemy)
+                c_te.firing_state = FiringState.FIRING
 
     
     

--- a/src/engine/game_engine.py
+++ b/src/engine/game_engine.py
@@ -3,7 +3,7 @@ import json
 import pygame
 import esper
 
-from src.create.prefab_creator import create_bullet, create_input_player, create_player, create_star, create_text
+from src.create.prefab_creator import create_bullet, create_enemy_bullet_spawner, create_input_player, create_player, create_star, create_text
 from src.create.prefab_creator import create_level
 from src.ecs.components.c_blink import CBlink
 from src.ecs.components.c_player_bullet_state import CPLayerBulletState, PlayerBulletState
@@ -93,6 +93,7 @@ class GameEngine:
         self._clean()
 
     def _create(self):
+        create_enemy_bullet_spawner(self.ecs_world, self.level_cfg)
         create_star(self.ecs_world, self.window_cfg, self.starfield_cfg)
         create_level(self.ecs_world, self.level_cfg, self.enemies_cfg)
         self._player_entity = create_player(self.ecs_world, self.player_cfg)
@@ -132,14 +133,13 @@ class GameEngine:
             system_explosion_state(self.ecs_world)
             system_bullet_limit(self.ecs_world, self.screen)
             system_player_limit(self.ecs_world, self.screen)
-            system_enemy_bullet_spawn(self.ecs_world, self.enemy_bullet_cfg, self.enemies_cfg, self.delta_time)
+            system_enemy_bullet_spawn(self.ecs_world, self.enemy_bullet_cfg, self.enemies_cfg, self.level_cfg, self.delta_time)
             system_collision_bullet_player(self.ecs_world, self.player_explosion_cfg)
 
             system_player_bullet_state(self.ecs_world, self.enemy_explosion_cfg, self)
 
             system_animation(self.ecs_world, self.delta_time)
             
-
             system_update_score(self.ecs_world,self.interface_cfg,self.enemies_cfg, self)
             system_update_high_score(self.ecs_world,self.interface_cfg, self)
             


### PR DESCRIPTION
- Closes #29 
- Añade un componente que ayuda a regular el delay entre los disparos de las balas enemigas
- Modifica `system_enemy_bullet_spawn` para que use el componente
- Añade el rango de los valores aleatorios al archivo de configuración del nivel, lo que permite fácilmente modificar qué tan largo es el intervalo

https://github.com/Laurarestrepo03/Ocarina-Galaxian/assets/69609680/c4bbead5-cba6-4aff-bc57-ca9cf77a1e99

