### PR TITLE
[Fix] Servicio para archivos de configuracion y otros ajustes

### DIFF
--- a/assets/cfg/enemies.json
+++ b/assets/cfg/enemies.json
@@ -15,7 +15,7 @@
                 }
             ]   
         },
-        "bullet_count": 2,
+        "bullet_count": 3,
         "points": 30
     },
     "invaders_enemy_02": {
@@ -34,7 +34,7 @@
                 }
             ]     
         },
-        "bullet_count": 2,
+        "bullet_count": 3,
         "points": 40
     },
     "invaders_enemy_03": {
@@ -53,7 +53,7 @@
                 }
             ]  
         },
-        "bullet_count": 2,
+        "bullet_count": 4,
         "points": 50
     },
     "invaders_enemy_04": {
@@ -72,7 +72,7 @@
                 }
             ]      
         },
-        "bullet_count": 2,
+        "bullet_count": 3,
         "points": 60
     }
 }

--- a/assets/cfg/enemies.json
+++ b/assets/cfg/enemies.json
@@ -15,7 +15,7 @@
                 }
             ]   
         },
-        "bullet_count": 3,
+        "bullet_count": 2,
         "points": 30
     },
     "invaders_enemy_02": {
@@ -34,7 +34,7 @@
                 }
             ]     
         },
-        "bullet_count": 3,
+        "bullet_count": 2,
         "points": 40
     },
     "invaders_enemy_03": {
@@ -53,7 +53,7 @@
                 }
             ]  
         },
-        "bullet_count": 4,
+        "bullet_count": 3,
         "points": 50
     },
     "invaders_enemy_04": {

--- a/assets/cfg/interface.json
+++ b/assets/cfg/interface.json
@@ -159,7 +159,7 @@
     },
     "game_over_help": {
         "font": "assets/fnt/PressStart2P.ttf",
-        "text": "Press Z to restart",
+        "text": "PRESS Z TO RESTART",
         "position": {
             "x": 128,
             "y": 162

--- a/assets/cfg/interface.json
+++ b/assets/cfg/interface.json
@@ -43,7 +43,7 @@
     },
     "high_score_value": {
         "font": "assets/fnt/PressStart2P.ttf",
-        "text": "480",
+        "text": "5000",
         "position": {
             "x": 131,
             "y": 24

--- a/assets/cfg/level_01.json
+++ b/assets/cfg/level_01.json
@@ -56,6 +56,6 @@
             "gap": 18
         }
     ],
-    "min_bullet_interval": 1,
-    "max_bullet_interval": 2
+    "min_bullet_interval": 0.1,
+    "max_bullet_interval": 0.6
 }

--- a/src/ecs/systems/s_collision_bullet_player.py
+++ b/src/ecs/systems/s_collision_bullet_player.py
@@ -17,7 +17,6 @@ def system_collision_bullet_player(ecs_world:esper.World, explosion_cfg:dict, ga
                 bl_rect = b_c_s.area.copy()
                 bl_rect.topleft = b_c_t.pos
                 if pl_rect.colliderect(bl_rect) and b_tb.type == BulletType.ENEMY:
-                    #TODO: quitar comentario cuando se implemente reinicio
                     p_c_s.visible= False
                     game_state.state = GameState.DEAD
                     game_state.number_lives -=1
@@ -27,7 +26,6 @@ def system_collision_bullet_player(ecs_world:esper.World, explosion_cfg:dict, ga
     
     for bullet_entity, (b_c_s, b_c_t, b_tb) in bullet_components:
         if (game_state.state == GameState.DEAD and b_tb.type == BulletType.PLAYER) or (game_state.state == GameState.GAME_OVER and b_tb.type == BulletType.PLAYER) :
-            #TODO: quitar comentario cuando se implemente reinicio
             b_c_s.visible= False
         else:
             b_c_s.visible= True

--- a/src/ecs/systems/s_enemy_bullet_spawn.py
+++ b/src/ecs/systems/s_enemy_bullet_spawn.py
@@ -41,7 +41,7 @@ def system_enemy_bullet_spawn(ecs_world:esper.World, bullet_cfg:dict, enemies_cf
                     c_te = ecs_world.component_for_entity(firing_enemy, CTagEnemy)
                     c_te.timer += delta_time
 
-                    if c_te.timer > 0.2:
+                    if c_te.timer > 0.15:
                         c_t = ecs_world.component_for_entity(firing_enemy, CTransform)
                         pos = c_t.pos.copy()
                         c_s = ecs_world.component_for_entity(firing_enemy, CSurface)

--- a/src/engine/game_engine.py
+++ b/src/engine/game_engine.py
@@ -1,10 +1,8 @@
 import asyncio
-import json
 import pygame
 import esper
 
 from src.create.prefab_creator import create_bullet, create_enemy_bullet_spawner, create_flag, create_input_player, create_life, create_player, create_star, create_text
-from src.create.prefab_creator import create_level
 from src.ecs.components.c_blink import CBlink
 from src.ecs.components.c_game_state import GameState, CGameState
 from src.ecs.components.c_level import CLevel
@@ -65,27 +63,16 @@ class GameEngine:
         # Original bg_color (0, 200, 128)
 
     def _load_config_files(self):
-        path = 'assets/cfg/'
-        with open(path + "window.json", encoding="utf-8") as window_file:
-            self.window_cfg = json.load(window_file)
-        with open(path + "player.json", encoding="utf-8") as player_file:
-            self.player_cfg = json.load(player_file)
-        with open(path + "player_bullet.json", encoding="utf-8") as player_bullet_file:
-            self.player_bullet_cfg = json.load(player_bullet_file)
-        with open(path + "enemy_bullet.json", encoding="utf-8") as enemy_bullet_file:
-            self.enemy_bullet_cfg = json.load(enemy_bullet_file)
-        with open(path + "starfield.json", encoding="utf-8") as starfield_file:
-            self.starfield_cfg = json.load(starfield_file)
-        with open(path + "level_01.json", encoding="utf-8") as level_file:
-            self.level_cfg = json.load(level_file)
-        with open(path + "enemies.json", encoding="utf-8") as enemies_file:
-            self.enemies_cfg = json.load(enemies_file)
-        with open(path + "enemy_explosion.json", encoding="utf-8") as enemy_explosion_file:
-            self.enemy_explosion_cfg = json.load(enemy_explosion_file)
-        with open(path + "player_explosion.json", encoding="utf-8") as player_explosion_file:
-            self.player_explosion_cfg = json.load(player_explosion_file)
-        with open(path + "interface.json", encoding="utf-8") as interface_file:
-            self.interface_cfg = json.load(interface_file)
+        self.enemies_cfg = ServiceLocator.config_service.enemies
+        self.enemy_bullet_cfg = ServiceLocator.config_service.enemy_bullet
+        self.enemy_explosion_cfg = ServiceLocator.config_service.enemy_explosion
+        self.interface_cfg = ServiceLocator.config_service.interface
+        self.level_cfg = ServiceLocator.config_service.level
+        self.player_bullet_cfg = ServiceLocator.config_service.player_bullet
+        self.player_explosion_cfg = ServiceLocator.config_service.player_explosion
+        self.player_cfg = ServiceLocator.config_service.player
+        self.starfield_cfg = ServiceLocator.config_service.starfield
+        self.window_cfg = ServiceLocator.config_service.window
             
     async def run(self) -> None:
         self._create()

--- a/src/engine/game_engine.py
+++ b/src/engine/game_engine.py
@@ -63,16 +63,16 @@ class GameEngine:
         # Original bg_color (0, 200, 128)
 
     def _load_config_files(self):
-        self.enemies_cfg = ServiceLocator.config_service.enemies
-        self.enemy_bullet_cfg = ServiceLocator.config_service.enemy_bullet
-        self.enemy_explosion_cfg = ServiceLocator.config_service.enemy_explosion
-        self.interface_cfg = ServiceLocator.config_service.interface
-        self.level_cfg = ServiceLocator.config_service.level
-        self.player_bullet_cfg = ServiceLocator.config_service.player_bullet
-        self.player_explosion_cfg = ServiceLocator.config_service.player_explosion
-        self.player_cfg = ServiceLocator.config_service.player
-        self.starfield_cfg = ServiceLocator.config_service.starfield
-        self.window_cfg = ServiceLocator.config_service.window
+        self.enemies_cfg = ServiceLocator.configs_service.enemies
+        self.enemy_bullet_cfg = ServiceLocator.configs_service.enemy_bullet
+        self.enemy_explosion_cfg = ServiceLocator.configs_service.enemy_explosion
+        self.interface_cfg = ServiceLocator.configs_service.interface
+        self.level_cfg = ServiceLocator.configs_service.level
+        self.player_bullet_cfg = ServiceLocator.configs_service.player_bullet
+        self.player_explosion_cfg = ServiceLocator.configs_service.player_explosion
+        self.player_cfg = ServiceLocator.configs_service.player
+        self.starfield_cfg = ServiceLocator.configs_service.starfield
+        self.window_cfg = ServiceLocator.configs_service.window
             
     async def run(self) -> None:
         self._create()

--- a/src/engine/service_locator.py
+++ b/src/engine/service_locator.py
@@ -1,3 +1,4 @@
+from src.engine.services.config_service import ConfigsService
 from src.engine.services.fonts_service import FontsService
 from src.engine.services.images_service import ImagesService
 from src.engine.services.sounds_service import SoundsService
@@ -6,3 +7,4 @@ class ServiceLocator:
     images_service = ImagesService()
     sounds_service = SoundsService()
     fonts_service = FontsService()
+    config_service = ConfigsService()

--- a/src/engine/service_locator.py
+++ b/src/engine/service_locator.py
@@ -1,8 +1,8 @@
-from src.engine.services.fonts_services import FontsServices
+from src.engine.services.fonts_service import FontsService
 from src.engine.services.images_service import ImagesService
 from src.engine.services.sounds_service import SoundsService
 
 class ServiceLocator:
     images_service = ImagesService()
     sounds_service = SoundsService()
-    fonts_service = FontsServices()
+    fonts_service = FontsService()

--- a/src/engine/service_locator.py
+++ b/src/engine/service_locator.py
@@ -1,4 +1,4 @@
-from src.engine.services.config_service import ConfigsService
+from src.engine.services.configs_service import ConfigsService
 from src.engine.services.fonts_service import FontsService
 from src.engine.services.images_service import ImagesService
 from src.engine.services.sounds_service import SoundsService
@@ -7,4 +7,4 @@ class ServiceLocator:
     images_service = ImagesService()
     sounds_service = SoundsService()
     fonts_service = FontsService()
-    config_service = ConfigsService()
+    configs_service = ConfigsService()

--- a/src/engine/services/config_service.py
+++ b/src/engine/services/config_service.py
@@ -1,0 +1,18 @@
+import json
+
+class ConfigsService:
+    def __init__(self) -> None:
+        self._prefix_path = "./assets/cfg/"
+        self._configs = {}
+            # Archivos personales de config precargados
+        self.window = self.get("window.json")
+        self.player = self.get("player.json")
+        self.enemies = self.get("enemies.json")
+            #... etcetera
+
+    def get(self, filename:str):
+        final_path = self._prefix_path + filename
+        if final_path not in self._configs:
+            with open(final_path, encoding="utf-8") as json_file:
+                self._configs[final_path] = json.load(json_file)
+        return self._configs[final_path]

--- a/src/engine/services/config_service.py
+++ b/src/engine/services/config_service.py
@@ -1,14 +1,28 @@
 import json
+import pathlib
+import os
 
 class ConfigsService:
     def __init__(self) -> None:
         self._prefix_path = "./assets/cfg/"
         self._configs = {}
-            # Archivos personales de config precargados
-        self.window = self.get("window.json")
-        self.player = self.get("player.json")
         self.enemies = self.get("enemies.json")
-            #... etcetera
+        self.enemy_bullet = self.get("enemy_bullet.json")
+        self.enemy_explosion = self.get("enemy_explosion.json")
+        self.interface = self.get("interface.json")
+        self.level = self.get("level_01.json")
+        self.player_bullet = self.get("player_bullet.json")
+        self.player_explosion = self.get("player_explosion.json")
+        self.player = self.get("player.json")
+        self.starfield = self.get("starfield.json")
+        self.window = self.get("window.json")
+
+        # # Precargar y asignar atributos a la clase con cada config
+        # for (_, _, files) in os.walk(self._prefix_path, topdown=True):
+        #     for file_path in files:
+        #         file_no_extension = pathlib.Path(file_path).stem # archivo sin extension
+        #         json_obj = self.get(file_path)
+        #         setattr(self, file_no_extension, json_obj)
 
     def get(self, filename:str):
         final_path = self._prefix_path + filename

--- a/src/engine/services/configs_service.py
+++ b/src/engine/services/configs_service.py
@@ -20,9 +20,9 @@ class ConfigsService:
         # # Precargar y asignar atributos a la clase con cada config
         # for (_, _, files) in os.walk(self._prefix_path, topdown=True):
         #     for file_path in files:
-        #         file_no_extension = pathlib.Path(file_path).stem # archivo sin extension
+        #         file_no_extension = pathlib.Path(file_path).stem # rchivo sin extension
         #         json_obj = self.get(file_path)
-        #         setattr(self, file_no_extension, json_obj)
+        #         setattr(self, file_no_extension, json_obj) # Igual a self.file = self.get(path)
 
     def get(self, filename:str):
         final_path = self._prefix_path + filename

--- a/src/engine/services/fonts_service.py
+++ b/src/engine/services/fonts_service.py
@@ -1,5 +1,3 @@
-
-
 import pygame
 
 class FontsService:

--- a/src/engine/services/fonts_service.py
+++ b/src/engine/services/fonts_service.py
@@ -2,7 +2,7 @@
 
 import pygame
 
-class FontsServices:
+class FontsService:
     def __init__(self) -> None:
         self._text = {}
 


### PR DESCRIPTION
- Closes #44 
- Closes #56 
- Crea un servicio para las configuraciones. Este servicio es la versión del documento de retroalimentación. La versión que nos mostró el profe en la reunión la dejé comentada. Tiene ventajas, pero lo malo es que no permite personalizar los nombres de los atributos
- Hace varios ajustes relacionados al disparo de las balas enemigas, en aras de aumentar la dificultad del juego:
   - Aumento en la cantidad de balas para los enemigos de arriba
   - Reducción en el intervalo de tiempo entres las balas de una ronda
   - Reducción en el intervalo de tiempo entre el disparo de los enemigos
- Cambia el valor del high score inicial a 5000, para que quede igual al ejemplo
- Cambia el texto de volver presionar Z para reiniciar a mayúsculas, porque me confundí y pensé que en ejemplo estaba en minúsculas