### PR TITLE
[Fix] Problemas de aparición de balas en ready y pause al morir

### DIFF
--- a/src/ecs/components/c_game_state.py
+++ b/src/ecs/components/c_game_state.py
@@ -19,5 +19,6 @@ class CGameState():
         self.time_game_over = 0
         self.game_over_text_created = False
         self.game__help_text_created = False
+        self.dead = False
 
 

--- a/src/ecs/systems/s_collision_bullet_player.py
+++ b/src/ecs/systems/s_collision_bullet_player.py
@@ -29,5 +29,7 @@ def system_collision_bullet_player(ecs_world:esper.World, explosion_cfg:dict, ga
             b_c_s.visible= False
         elif (game_state.state == GameState.WIN and b_tb.type == BulletType.ENEMY):
             b_c_s.visible= False
+        elif (game_state.state == GameState.READY and b_tb.type == BulletType.ENEMY):
+            b_c_s.visible= False
         else:
             b_c_s.visible= True

--- a/src/ecs/systems/s_game_manager.py
+++ b/src/ecs/systems/s_game_manager.py
@@ -64,6 +64,7 @@ def system_game_manager(world : esper.World, delta_time: float, level_cfg, enemi
             manager_component.current_enemyes = enemies
         
         elif manager_component.state == GameState.DEAD:
+            manager_component.dead = True
             manager_component.time_dead += delta_time
 
             if  manager_component.time_dead >= 3:
@@ -76,6 +77,7 @@ def system_game_manager(world : esper.World, delta_time: float, level_cfg, enemi
                     ServiceLocator.sounds_service.play(interface_cfg["game_over"]["sound"])
                     manager_component.game_over_text_created = True
                 else:
+                    manager_component.dead = False
                     size = player_surface.area.size
                     player_pos.pos = pygame.Vector2(player_info["spawn_point"]["x"] - (size[0]/2),
                             player_info["spawn_point"]["y"] - (size[1]/2))

--- a/src/engine/game_engine.py
+++ b/src/engine/game_engine.py
@@ -197,7 +197,7 @@ class GameEngine:
                 c_v.vel = vel
         if c_input.name == "PAUSE":
             if c_input.phase == CommandPhase.START:
-                if self.game_state.state == GameState.PLAY:
+                if self.game_state.state == GameState.PLAY or self.game_state.state == GameState.DEAD:
                     self.game_state.state = GameState.PAUSED
                     pause_text_entity = create_text(self.ecs_world, self.interface_cfg["pause"])
                     self.ecs_world.add_component(pause_text_entity, CBlink(0.5, 0.5))
@@ -205,7 +205,11 @@ class GameEngine:
                     ServiceLocator.sounds_service.play(self.interface_cfg["pause"]["sound"])
                 else:
                     if self.game_state.state == GameState.PAUSED:
-                        self.game_state.state = GameState.PLAY
+                        if self.game_state.dead == True:
+                            self.game_state.state = GameState.DEAD
+                            self.game_state.dead=False
+                        else:
+                            self.game_state.state = GameState.PLAY
                         system_pause(self.ecs_world)
         if c_input.name == "PLAYER_FIRE" and c_input.phase == CommandPhase.START and self.game_state.state == GameState.GAME_OVER:
             enemyes = self.ecs_world.get_components(CTagEnemy)


### PR DESCRIPTION
Cambios para evitar la aparición de las balas al reiniciar inmediatamente el juego. Implementación de pause al momento de morir.